### PR TITLE
Add Off Grid - on-device Stable Diffusion for mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 - [Plush-for-ComfyUI](https://github.com/glibsonoran/Plush-for-ComfyUI) : Custom node for ComfyUI/Stable Diffustion
 - [Krita AI Diffusion](https://github.com/Acly/krita-ai-diffusion) : Streamlined interface for generating images with AI in Krita. Inpaint and outpaint with optional text prompt, no tweaking required.
 - [LyCORIS](https://github.com/KohakuBlueleaf/LyCORIS): Lora beYond Conventional methods, Other Rank adaptation Implementations for Stable diffusion.
+- [Off Grid](https://github.com/alichherawalla/off-grid-mobile): On-device Stable Diffusion for mobile (Android & iOS). NPU-accelerated on Snapdragon (5-10s per image), Core ML on iOS. 20+ models including Absolute Reality, DreamShaper, Anything V5. Also supports LLM text generation, vision AI, and voice transcription — all offline.
 
 - [ControlNet](https://github.com/lllyasviel/ControlNet): Add condition control to Stable Diffusion models.
 - [sd-webui-controlnet](https://github.com/Mikubill/sd-webui-controlnet): Extension enabling ControlNet in AUTOMATIC1111's web UI.


### PR DESCRIPTION
## Add Off Grid to the list

[Off Grid](https://github.com/alichherawalla/off-grid-mobile) runs Stable Diffusion entirely on mobile phones (Android & iOS).

### Image generation features
- NPU-accelerated on Snapdragon (5-10s per image), Core ML on iOS
- Real-time preview during generation
- 20+ models including Absolute Reality, DreamShaper, Anything V5
- AI prompt enhancement — simple text in, detailed SD prompt out

### Also includes
- LLM text generation (Qwen 3, Llama 3.2, Gemma 3, any GGUF)
- Vision AI and voice transcription

Open source (MIT), 100% offline, available on [Google Play](https://play.google.com/store/apps/details?id=ai.offgridmobile).