### PR TITLE
Add comfy-vault (ComfyUI model cleanup CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
 - [Dreambooth-Stable-Diffusion](https://github.com/XavierXiao/Dreambooth-Stable-Diffusion): DreamBooth fine-tuning for Stable Diffusion.
 - [sygil-webui](https://github.com/Sygil-Dev/sygil-webui): Feature-rich fork of Stable Diffusion Web UI.
 - [adetailer](https://github.com/Bing-su/adetailer): Automatic detailing extension for Stable Diffusion Web UI.
+- [comfy-vault](https://github.com/Chepko932/comfy-vault): Standalone CLI that finds unused models and broken LoRAs in a ComfyUI install.
 
 ### Jupyter Notebook
 - [anime-webui-colab](https://github.com/NUROISEA/anime-webui-colab): A collection of stable diffusion web ui colabs primarily focusing on anime


### PR DESCRIPTION
Adds **comfy-vault** under Python — a standalone CLI that finds unused/orphan models and byte-exact duplicate LoRAs in a ComfyUI install (also Civitai metadata lookup by file hash).

- MIT licensed, on PyPI as `comfy-model-vault`, CI green on Linux + Windows (3.10–3.12).
- Runs without ComfyUI, so it also works on a backup/NAS host.
- Repo: https://github.com/Chepko932/comfy-vault

Placed it at the bottom of the Python section to match the list style. Thanks for maintaining the list!