### PR TITLE
Add Image MetaHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 - [Krita AI Diffusion](https://github.com/Acly/krita-ai-diffusion) : Streamlined interface for generating images with AI in Krita. Inpaint and outpaint with optional text prompt, no tweaking required.
 - [LyCORIS](https://github.com/KohakuBlueleaf/LyCORIS): Lora beYond Conventional methods, Other Rank adaptation Implementations for Stable diffusion.
 - [Off Grid AI Desktop](https://github.com/off-grid-ai/off-grid-ai-desktop): Open-source (AGPL-3.0) macOS app with on-device Stable Diffusion image generation running fully local; part of a local-first AI suite (LLM chat, dictation, RAG). No account, no telemetry, no cloud. Site https://getoffgridai.co/desktop.
+- [Image MetaHub](https://github.com/LuqP2/Image-MetaHub): Local-first desktop app to search and organize AI-generated images by prompt, model, LoRA, seed, and full ComfyUI workflow metadata. Windows/macOS/Linux, fully offline. Free with optional Pro.
 
 - [ControlNet](https://github.com/lllyasviel/ControlNet): Add condition control to Stable Diffusion models.
 - [sd-webui-controlnet](https://github.com/Mikubill/sd-webui-controlnet): Extension enabling ControlNet in AUTOMATIC1111's web UI.


### PR DESCRIPTION
Image MetaHub is a local-first desktop app to search and organize AI-generated images by prompt, model, LoRA, seed, and full ComfyUI workflow metadata. Windows/macOS/Linux, fully offline. Free with optional Pro. https://github.com/LuqP2/Image-MetaHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an Image MetaHub resource link to the Python Stable Diffusion resource list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->