### PR TITLE
Add: Imference-Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 - [LyCORIS](https://github.com/KohakuBlueleaf/LyCORIS): Lora beYond Conventional methods, Other Rank adaptation Implementations for Stable diffusion.
 - [Off Grid AI Desktop](https://github.com/off-grid-ai/off-grid-ai-desktop): Open-source (AGPL-3.0) macOS app with on-device Stable Diffusion image generation running fully local; part of a local-first AI suite (LLM chat, dictation, RAG). No account, no telemetry, no cloud. Site https://getoffgridai.co/desktop.
 - [Image MetaHub](https://github.com/LuqP2/Image-MetaHub): Local-first desktop app to search and organize AI-generated images by prompt, model, LoRA, seed, and full ComfyUI workflow metadata. Windows/macOS/Linux, fully offline. Free with optional Pro.
+- [Imference Desktop](https://github.com/Publikey/imference-desktop): Open-source local-first desktop app (Windows/macOS) for AI image generation. One-click setup with an isolated engine, auto GPU detection and VRAM tuning; runs SDXL, SD 1.5, FLUX, Qwen-Image and more, loads custom .safetensors.
 - [ImageBench](https://github.com/dh7/image-bench-ai): Open text-to-image benchmark ranking 50+ models (Flux 2 Pro/Max/Klein, Qwen Image, Sana, Recraft V3, Ideogram v3/v4, Seedream V4/V5, Nano Banana, GPT Image 2, Imagen 4, and more) on 192 prompts across 6 categories using VLM judges. Every generated image is published — no cherry-picking. Live leaderboard and side-by-side comparisons at https://imagebench.ai.
 
 - [ControlNet](https://github.com/lllyasviel/ControlNet): Add condition control to Stable Diffusion models.


### PR DESCRIPTION
Adds Imference Desktop to the Python section, next to the other local-first desktop apps (Off Grid AI Desktop, Image MetaHub).

It's an open-source desktop app (Windows/macOS) for running Stable Diffusion models locally — SDXL, SD 1.5, FLUX, Qwen-Image and more. One-click setup: the app installs an isolated Python inference engine (built on diffusers), detects the GPU and tunes offloading/quantization to the available VRAM. MIT licensed, active development.

Disclosure: I'm the author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Imference Desktop to the Python Stable Diffusion resources list.
  * Included information about supported platforms, setup, hardware detection, tuning, and model support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->