### PR TITLE
Restructure README by use-case (Awesome standards)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,117 +1,98 @@
-# NEW: Awesome Stable Diffusion ⭐
-<img alt="Awesome Stable Diffusion" src="https://repository-images.githubusercontent.com/613279917/f67c116d-b238-432e-8fa9-db17c8c9ac71">
-<br>
-<p align="center">
+# Awesome Stable Diffusion [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
-<img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/doanbactam/awesome-stable-diffusion">
-<img alt="GitHub contributors" src="https://img.shields.io/github/contributors/doanbactam/awesome-stable-diffusion">
-<img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/doanbactam/awesome-stable-diffusion?style=social">
-<img alt="GitHub" src="https://img.shields.io/github/license/doanbactam/awesome-stable-diffusion">
+> A curated list of high-quality tools, UIs, libraries, and resources for Stable Diffusion and modern diffusion image models.
 
-</p>
+## Contents
 
-<h3>Help this grow and get discovered by other devs with a ⭐ star.</h3>
+- [Start here](#start-here)
+- [UIs](#uis)
+- [Libraries](#libraries)
+- [Training](#training)
+- [Control and conditioning](#control-and-conditioning)
+- [Upscale and restore](#upscale-and-restore)
+- [Local and edge](#local-and-edge)
+- [Integrations](#integrations)
+- [Video and 3D](#video-and-3d)
+- [Desktop apps](#desktop-apps)
+- [Contributing](#contributing)
 
-# Table of Contents
+## Start here
 
-- [Stable Diffusion](#stable-diffusion)
-    - [Python](#python)
-    - [Jupyter Notebook](#jupyter-notebook)
-    - [JavaScript](#javascript)
-    - [TypeScript](#typescript)
-    - [PHP](#php)
-    - [Swift](#swift)
-    - [Dockerfile](#dockerfile)
-    - [Vue](#vue)
-    - [Flutter](#flutter)
-    - [C/C++](#c)
+- [ComfyUI](https://github.com/comfyanonymous/ComfyUI) - Modular node-based GUI and backend for diffusion models.
+- [Diffusers](https://github.com/huggingface/diffusers) - State-of-the-art diffusion models library for image, video, and audio in PyTorch.
+- [kohya_ss](https://github.com/bmaltais/kohya_ss) - GUI for training LoRA and DreamBooth models.
 
-## 👑Stable Diffusion
+## UIs
 
-### Python
+- [ComfyUI](https://github.com/comfyanonymous/ComfyUI) - Most powerful modular diffusion GUI with a graph/nodes interface.
+- [Stable Diffusion web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui) - Widely used Gradio-based Stable Diffusion web UI.
+- [automatic](https://github.com/vladmandic/automatic) - Opinionated, actively maintained fork of Stable Diffusion WebUI.
+- [Fooocus](https://github.com/lllyasviel/Fooocus) - Minimal, user-friendly interface focused on good defaults.
+- [InvokeAI](https://github.com/invoke-ai/InvokeAI) - Creative engine aimed at professionals and enthusiasts.
+- [ComfyUI-Manager](https://github.com/ltdrdata/ComfyUI-Manager) - Install and manage custom nodes for ComfyUI.
 
-- [Stable Diffusion web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui): Stable Diffusion web UI
-- [ComfyUI](https://github.com/comfyanonymous/ComfyUI): The most powerful and modular diffusion model GUI, api and backend with a graph/nodes interface.
-- [Diffusers](https://github.com/huggingface/diffusers): State-of-the-art diffusion models for image, video, and audio generation in PyTorch.
-- [IOPaint](https://github.com/Sanster/IOPaint): Image inpainting tool powered by SOTA AI models (formerly lama-cleaner).
-- [fast-stable-diffusion](https://github.com/TheLastBen/fast-stable-diffusion): Notebooks for AUTOMATIC1111 + DreamBooth.
-- [Dream textures](https://github.com/carson-katri/dream-textures): Stable Diffusion built-in to Blender.
-- [Stable-Dreamfusion](https://github.com/ashawkey/stable-dreamfusion): Text-to-3D with Stable Diffusion.
-- [dream-factory](https://github.com/rbbrdckybk/dream-factory): Multi-threaded GUI for mass AI art generation with multi-GPU support.
-- [stable-diffusion-videos](https://github.com/nateraw/stable-diffusion-videos): Create videos by morphing between text prompts in latent space.
-- [automatic](https://github.com/vladmandic/automatic): Opinionated fork/implementation of Stable Diffusion.
-- [StyleTTS2](https://github.com/yl4579/StyleTTS2): Text-to-Speech through style diffusion and adversarial training.
-- [i2vgen-xl](https://github.com/ali-vilab/i2vgen-xl): Video generation ecosystem built on diffusion models.
-- [nodetool](https://github.com/nodetool-ai/nodetool): Node-based creative AI playground.
-- [Plush-for-ComfyUI](https://github.com/glibsonoran/Plush-for-ComfyUI): Custom nodes for ComfyUI.
-- [Krita AI Diffusion](https://github.com/Acly/krita-ai-diffusion): Streamlined AI image generation inside Krita.
-- [LyCORIS](https://github.com/KohakuBlueleaf/LyCORIS): LoRA beyond conventional methods for Stable Diffusion.
-- [Off Grid AI Desktop](https://github.com/off-grid-ai/off-grid-ai-desktop): Local-first macOS app for on-device Stable Diffusion.
-- [Image MetaHub](https://github.com/LuqP2/Image-MetaHub): Local-first desktop app to search AI images by prompt, model, LoRA, and ComfyUI workflow metadata.
-- [Imference Desktop](https://github.com/Publikey/imference-desktop): Local-first desktop app for SDXL, SD 1.5, FLUX and custom safetensors.
-- [ImageBench](https://github.com/dh7/image-bench-ai): Open text-to-image benchmark ranking 50+ models with published outputs.
-- [ControlNet](https://github.com/lllyasviel/ControlNet): Add condition control to Stable Diffusion models.
-- [sd-webui-controlnet](https://github.com/Mikubill/sd-webui-controlnet): ControlNet extension for AUTOMATIC1111 web UI.
-- [sd-scripts](https://github.com/kohya-ss/sd-scripts): Training scripts for DreamBooth and LoRA.
-- [kohya_ss](https://github.com/bmaltais/kohya_ss): GUI for training LoRA models with Stable Diffusion.
-- [Real-ESRGAN](https://github.com/xinntao/Real-ESRGAN): AI-powered image upscaler often paired with Stable Diffusion.
-- [Fooocus](https://github.com/lllyasviel/Fooocus): User-friendly interface for running Stable Diffusion.
-- [ComfyUI-Manager](https://github.com/ltdrdata/ComfyUI-Manager): Manage and install custom nodes for ComfyUI.
-- [sd-webui-additional-networks](https://github.com/kohya-ss/sd-webui-additional-networks): Load LoRA and other networks in A1111 Web UI.
-- [adetailer](https://github.com/Bing-su/adetailer): Automatic detailing extension for Stable Diffusion Web UI.
+## Libraries
 
-### Jupyter Notebook
+- [Diffusers](https://github.com/huggingface/diffusers) - Official Hugging Face library for diffusion pipelines and training helpers.
+- [LyCORIS](https://github.com/KohakuBlueleaf/LyCORIS) - Extended LoRA-style adapters beyond conventional methods.
 
-- [InvokeAI](https://github.com/invoke-ai/InvokeAI): Creative engine for professionals and enthusiasts.
-- [stable-diffusion-webui-colab](https://github.com/camenduru/stable-diffusion-webui-colab): One-click Colab setup for AUTOMATIC1111 web UI.
-- [stable-diffusion](https://github.com/FurkanGozukara/Stable-Diffusion): Tutorials and notebooks for FLUX, SDXL, SD3, LoRA, Forge, ComfyUI, and more.
-- [paper2gui](https://github.com/Baiyuetribe/paper2gui): Convert AI papers into usable GUIs.
+## Training
 
-### JavaScript
+- [sd-scripts](https://github.com/kohya-ss/sd-scripts) - Core training scripts for DreamBooth and LoRA.
+- [kohya_ss](https://github.com/bmaltais/kohya_ss) - Popular GUI wrapper around kohya training scripts.
+- [LyCORIS](https://github.com/KohakuBlueleaf/LyCORIS) - Alternative network architectures for efficient fine-tuning.
 
-- [Easy Diffusion](https://github.com/easydiffusion/easydiffusion): Simple 1-click local Stable Diffusion (formerly stable-diffusion-ui).
-- [Auto-Photoshop-StableDiffusion-Plugin](https://github.com/AbdullahAlfaraj/Auto-Photoshop-StableDiffusion-Plugin): Generate Stable Diffusion images inside Photoshop via A1111 backend.
-- [openOutpaint](https://github.com/zero01101/openOutpaint): In-browser outpainting tool for Stable Diffusion.
-- [web-stable-diffusion](https://github.com/mlc-ai/web-stable-diffusion): Run Stable Diffusion in the browser with WebGPU.
+## Control and conditioning
 
-### TypeScript
+- [ControlNet](https://github.com/lllyasviel/ControlNet) - Add spatial conditions (pose, depth, edges) to diffusion models.
+- [sd-webui-controlnet](https://github.com/Mikubill/sd-webui-controlnet) - ControlNet extension for AUTOMATIC1111 WebUI.
+- [sd-webui-additional-networks](https://github.com/kohya-ss/sd-webui-additional-networks) - Load LoRA and extra networks in A1111 WebUI.
+- [adetailer](https://github.com/Bing-su/adetailer) - Automatic detection and detailing extension for WebUI.
 
-- [civitai](https://github.com/civitai/civitai): Repository of models, textual inversions, and more.
-- [big-AGI](https://github.com/enricoros/big-AGI): AI suite with multi-model chat, text-to-image, and more.
-- [sd-webui-lobe-theme](https://github.com/lobehub/sd-webui-lobe-theme): Modern theme for Stable Diffusion WebUI.
+## Upscale and restore
 
-### PHP
+- [Real-ESRGAN](https://github.com/xinntao/Real-ESRGAN) - Practical AI image upscaler commonly used with Stable Diffusion.
+- [IOPaint](https://github.com/Sanster/IOPaint) - Inpainting and object removal powered by modern AI models.
 
-- [pokemon-card-generator](https://github.com/robiningelbrecht/pokemon-card-generator): Generate Pokemon cards with GPT and Stable Diffusion.
+## Local and edge
 
-### Swift
+- [stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp) - Stable Diffusion and Flux inference in pure C/C++.
+- [MochiDiffusion](https://github.com/godly-devotion/MochiDiffusion) - Native Stable Diffusion on Mac.
+- [web-stable-diffusion](https://github.com/mlc-ai/web-stable-diffusion) - Run Stable Diffusion in the browser with WebGPU.
 
-- [MochiDiffusion](https://github.com/godly-devotion/MochiDiffusion): Run Stable Diffusion natively on Mac.
+## Integrations
 
-### Dockerfile
+- [Krita AI Diffusion](https://github.com/Acly/krita-ai-diffusion) - Generate and inpaint with AI inside Krita.
+- [Dream textures](https://github.com/carson-katri/dream-textures) - Stable Diffusion integration for Blender.
+- [Auto-Photoshop-StableDiffusion-Plugin](https://github.com/AbdullahAlfaraj/Auto-Photoshop-StableDiffusion-Plugin) - Generate images inside Photoshop via A1111 backend.
 
-- [Stable Diffusion WebUI Docker](https://github.com/AbdBarho/stable-diffusion-webui-docker): Easy Docker setup for Stable Diffusion with user-friendly UI.
+## Video and 3D
 
-### Vue
+- [stable-diffusion-videos](https://github.com/nateraw/stable-diffusion-videos) - Create videos by morphing between text prompts in latent space.
+- [i2vgen-xl](https://github.com/ali-vilab/i2vgen-xl) - Video generation ecosystem built on diffusion models.
+- [Stable-Dreamfusion](https://github.com/ashawkey/stable-dreamfusion) - Text-to-3D generation powered by Stable Diffusion.
 
-- [geekai](https://github.com/yangjian102621/geekai): Full AI assistant stack with Stable Diffusion painting support.
+## Desktop apps
 
-### Flutter
+- [Easy Diffusion](https://github.com/easydiffusion/easydiffusion) - Simple one-click local installation for non-technical users.
+- [Off Grid AI Desktop](https://github.com/off-grid-ai/off-grid-ai-desktop) - Local-first macOS app for on-device image generation.
+- [Imference Desktop](https://github.com/Publikey/imference-desktop) - Local desktop app supporting SDXL, SD 1.5, FLUX, and custom weights.
+- [Image MetaHub](https://github.com/LuqP2/Image-MetaHub) - Search and organize AI images by prompt, model, LoRA, and workflow metadata.
+- [ImageBench](https://github.com/dh7/image-bench-ai) - Open benchmark ranking text-to-image models with published outputs.
 
-- [flutter_scribble](https://github.com/lahirumaramba/flutter_scribble): Turn scribbles into detailed images with AI.
+## Contributing
 
-### C/C++
+Contributions welcome. Please:
 
-- [stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp): Stable Diffusion and Flux inference in pure C/C++.
+- Add only actively maintained, high-quality projects.
+- Use the format: `- [Name](url) - Short neutral description.`
+- Place items in the most relevant section.
+- Open a pull request with a clear reason for the addition.
 
-## ⭐️ Star History
+See the [Awesome manifesto](https://github.com/sindresorhus/awesome/blob/main/awesome.md) for curation guidelines.
 
-<a href="https://star-history.com/#doanbactam/awesome-stable-diffusion&Date">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=doanbactam/awesome-stable-diffusion&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=doanbactam/awesome-stable-diffusion&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=doanbactam/awesome-stable-diffusion&type=Date" />
- </picture>
-</a>
+## License
 
-A curated list of awesome stable diffusion resources 🌟
+[![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)
+
+To the extent possible under law, the contributors have waived all copyright and related or neighboring rights to this work.


### PR DESCRIPTION
Rewrite README to follow Awesome list standards and modern SD workflows.

**Changes:**
- Title + official Awesome badge
- Short scope description
- `Contents` section (one level)
- Categories by **use-case** instead of language:
  - Start here, UIs, Libraries, Training, Control, Upscale, Local/edge, Integrations, Video/3D, Desktop apps
- Consistent entry format: `- [Name](url) - Description.`
- CONTRIBUTING + CC0 license section
- Only curated, maintained projects kept

Aligned with [sindresorhus/awesome](https://github.com/sindresorhus/awesome) guidelines.