### PR TITLE
Add VideoHelperSuite, Frame-Interpolation, and 3D-Pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@
 - [i2vgen-xl](https://github.com/ali-vilab/i2vgen-xl) - Video generation ecosystem built on diffusion models.
 - [Stable-Dreamfusion](https://github.com/ashawkey/stable-dreamfusion) - Text-to-3D generation powered by Stable Diffusion.
 - [ComfyUI-WanVideoWrapper](https://github.com/kijai/ComfyUI-WanVideoWrapper) - Wrapper nodes for Wan video generation models in ComfyUI.
+- [ComfyUI-VideoHelperSuite](https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite) - Nodes for video loading, combining, batching, and frame utilities in ComfyUI.
+- [ComfyUI-Frame-Interpolation](https://github.com/Fannovel16/ComfyUI-Frame-Interpolation) - Video frame interpolation nodes supporting RIFE, FILM, GMFSS and other VFI models.
+- [ComfyUI-3D-Pack](https://github.com/MrForExample/ComfyUI-3D-Pack) - Nodes for 3D mesh, 3DGS, and NeRF generation from images in ComfyUI.
 
 ## Desktop apps
 


### PR DESCRIPTION
Add three maintained ComfyUI node packs to **Video and 3D**:

- [ComfyUI-VideoHelperSuite](https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite) — video load/combine/batch utilities (~1.8k stars, active).
- [ComfyUI-Frame-Interpolation](https://github.com/Fannovel16/ComfyUI-Frame-Interpolation) — VFI nodes (RIFE, FILM, GMFSS; ~1.1k stars).
- [ComfyUI-3D-Pack](https://github.com/MrForExample/ComfyUI-3D-Pack) — mesh / 3DGS / NeRF nodes (~3.9k stars).

None of these are in the current README. Format matches contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added three new entries to the “Video and 3D” section:
    * ComfyUI-VideoHelperSuite
    * ComfyUI-Frame-Interpolation
    * ComfyUI-3D-Pack
  * Included brief descriptions for each entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->