### PR TITLE
Add Mold — CLI-native local AI image/video/3D generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
 - [web-stable-diffusion](https://github.com/mlc-ai/web-stable-diffusion) - Run Stable Diffusion in the browser with WebGPU.
 - [ComfyUI-GGUF](https://github.com/city96/ComfyUI-GGUF) - GGUF quantization support for native ComfyUI models (FLUX/SD3).
 - [mflux](https://github.com/filipstrand/mflux) - Native MLX port of FLUX and related models for Apple Silicon.
+- [Mold](https://github.com/utensils/mold) - CLI-native local AI image/video/3D generation in Rust/Candle with CUDA/Metal and MCP.
 - [ComfyUI-nunchaku](https://github.com/nunchaku-ai/ComfyUI-nunchaku) - ComfyUI nodes for 4-bit SVDQuant inference of FLUX and related models.
 
 ## Integrations


### PR DESCRIPTION
Adds [Mold](https://github.com/utensils/mold) under **Local and edge**.

Mold is a CLI-native local AI image/video/3D generation tool (Rust/Candle, CUDA/Metal, MCP) that fits alongside other local/edge diffusion runtimes like mflux and stable-diffusion.cpp.

Homepage: https://utensils.io/mold/
License: MIT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Mold to the README’s “Local and edge” resources, including a link and a brief description of its local AI image, video, and 3D generation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->